### PR TITLE
[JENKINS-17479] URL SCM always marks URL as changed with Poll SCM option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.392</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.420</version>
   </parent>
 
+  <groupId>org.jvnet.hudson.plugins</groupId>
   <artifactId>URLSCM</artifactId>
   <packaging>hpi</packaging>
   <version>1.7-SNAPSHOT</version>

--- a/src/main/java/hudson/plugins/URLSCM/URLDateAction.java
+++ b/src/main/java/hudson/plugins/URLSCM/URLDateAction.java
@@ -1,8 +1,7 @@
 package hudson.plugins.URLSCM;
 
-import hudson.model.Action;
 import hudson.model.AbstractBuild;
-import hudson.model.AbstractModelObject;
+import hudson.scm.SCMRevisionState;
 
 import java.io.IOException;
 import java.text.DateFormat;
@@ -15,21 +14,18 @@ import javax.servlet.ServletException;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-public class URLDateAction extends AbstractModelObject implements Action {
-    /**
-     * 
-     */
-    private static final long           serialVersionUID = 1L;
+public class URLDateAction extends SCMRevisionState {
+    private static final long serialVersionUID = 1L;
 
-    private final HashMap<String, Long> lastModified     = new HashMap<String, Long>();
+    private final HashMap<String, Long> lastModified = new HashMap<String, Long>();
 
-    private final AbstractBuild         build;
+    private final AbstractBuild<?, ?> build;
 
-    protected URLDateAction(final AbstractBuild build) {
+    protected URLDateAction(final AbstractBuild<?, ?> build) {
         this.build = build;
     }
 
-    public AbstractBuild getBuild() {
+    public AbstractBuild<?, ?> getBuild() {
         return build;
     }
 
@@ -60,10 +56,12 @@ public class URLDateAction extends AbstractModelObject implements Action {
         return ret;
     }
 
+    @Override
     public String getDisplayName() {
         return "URL Modification Dates";
     }
 
+    @Override
     public String getIconFileName() {
         return "save.gif";
     }
@@ -72,6 +70,7 @@ public class URLDateAction extends AbstractModelObject implements Action {
         return getUrlName();
     }
 
+    @Override
     public String getUrlName() {
         return "urlDates";
     }


### PR DESCRIPTION
I noticed that Jenkins now calls 'compareRemoteRevisionWith()' instead of 'pollChanges()', but the former always returns 'PollingResult.BUILD_NOW' and so triggers a new build. Now I have just moved the former logic of 'pollChanges()' to 'compareRemoteRevisionWith()', seems to work in my case for the last 14 days.
